### PR TITLE
fix container exclude, since it was giving error showing as invalid. 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - DD_APM_NON_LOCAL_TRAFFIC=true
       - DD_LOGS_ENABLED=true
       - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
-      - DD_CONTAINER_EXCLUDE="name:datadog-agent"
+      - DD_CONTAINER_EXCLUDE=name:datadog-agent
       - DD_PROCESS_AGENT_ENABLED=true
       - DD_COMPLIANCE_CONFIG_ENABLED=true
       - DD_RUNTIME_SECURITY_CONFIG_ENABLED=true


### PR DESCRIPTION
>   Container Inclusion/Exclusion Errors
  ====================================
    Container filter "\"name:datadog-agent\"" is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'